### PR TITLE
Significantly Improve Processing Speed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ interface IConvTableEntry {
 }
 type ConvTable = IConvTableEntry[]
 type ConvTableName = "0273" | "0037" | "0278"
+type QuickLookupTable = { [name: string]: string }
 
 const convTables = {
   "0273": germanCodeset,
@@ -21,18 +22,28 @@ const convTables = {
  * Class for converting between EBCDIC and ASCII (ISO-8859-1)
  */
 export default class EbcdicAscii {
-  table: ConvTable
+  asciiToEbcdicTable: QuickLookupTable = {}
+  ebcdicToAsciiTable: QuickLookupTable = {}
 
   /**
    *
    * @param tableName string - May be "0273" for german, "0037" for english and "0278" for finnish/swedish
    */
   constructor(tableName: ConvTableName) {
-    this.table = convTables[tableName]
+    this.setTable(tableName)
   }
 
   setTable(tableName: ConvTableName) {
-    this.table = convTables[tableName]
+    const simpleTable: ConvTable = convTables[tableName]
+    
+    simpleTable.forEach((tableItem) => {
+      const asciiCode: string = tableItem.hex; 
+      const ebcdicEntry = simpleTable.find((e) => e.ebcdic === tableItem?.ascii)
+      const ebcdicCode: string = ebcdicEntry ? ebcdicEntry.hex : "00"
+
+      this.asciiToEbcdicTable[asciiCode] = ebcdicCode
+      this.ebcdicToAsciiTable[ebcdicCode] = asciiCode
+    })
   }
 
   /**
@@ -81,16 +92,11 @@ export default class EbcdicAscii {
    * @param ebcdic string - Hex code for a EBCDIC char
    */
   charToASCII(ebcdicCode: string) {
-    if (ebcdicCode.length > 2) {
-      throw new Error("Invalid char sequence size")
+    const asciiCode = this.ebcdicToAsciiTable[ebcdicCode];
+    if (asciiCode === undefined) {
+      throw new Error(`Invalid char sequence ${ebcdicCode}`)
     }
-
-    const ebcdicEntry = this.table.find((e) => e.hex === ebcdicCode)
-    const asciiEntry = this.table.find((e) => e.ascii === ebcdicEntry?.ebcdic)
-    if (asciiEntry === undefined) {
-      return "00"
-    }
-    return asciiEntry.hex
+    return asciiCode; 
   }
 
   /**
@@ -98,15 +104,10 @@ export default class EbcdicAscii {
    * @param ebcdic string - Hex code for an ASCII char
    */
   charToEBCDIC(asciiCode: string) {
-    if (asciiCode.length > 2) {
-      throw new Error("Invalid char sequence size")
+    const ebcdicCode = this.ebcdicToAsciiTable[asciiCode];
+    if (ebcdicCode === undefined) {
+      throw new Error(`Invalid char sequence ${asciiCode}`)
     }
-
-    const asciiEntry = this.table.find((e) => e.hex === asciiCode)
-    const ebcdicEntry = this.table.find((e) => e.ebcdic === asciiEntry?.ascii)
-    if (ebcdicEntry === undefined) {
-      return "00"
-    }
-    return ebcdicEntry.hex
+    return ebcdicCode; 
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export default class EbcdicAscii {
       this.asciiToEbcdicTable[asciiCode] = ebcdicCode
       this.ebcdicToAsciiTable[ebcdicCode] = asciiCode
     })
+    this.ebcdicToAsciiTable["00"] = "00"
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,10 +101,10 @@ export default class EbcdicAscii {
 
   /**
    * Convert an ASCII hex char to a EBCDIC hex char
-   * @param ebcdic string - Hex code for an ASCII char
+   * @param ascii string - Hex code for an ASCII char
    */
   charToEBCDIC(asciiCode: string) {
-    const ebcdicCode = this.ebcdicToAsciiTable[asciiCode];
+    const ebcdicCode = this.asciiToEbcdicTable[asciiCode];
     if (ebcdicCode === undefined) {
       throw new Error(`Invalid char sequence ${asciiCode}`)
     }


### PR DESCRIPTION
The previous code does a lookup using two for-loops that each loop over tables of approximately 800 items, and it does so on every single character. This can add up to costing ~800x more than necessary, which will be significant for processing larger bodies of text. One may want to convert files many GBs large to different file formats, so optimization is important. 

This PR will increase memory usage, but but by a small set amount. The optimization works by doing one loop over the table, up-front, to construct two fast lookup dictionaries that work in constant time. 