### PR TITLE
Added support for 1047 Latin 1/Open Systems codeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Supported EBCDIC codesets:
 - 0037: English
 - 0273: German
 - 0278: Finnish/Swedish
+- 1047: Latin 1/Open Systems
 
-EBCDIC codesets were taken from [longpelaexpertise.com](http://www.longpelaexpertise.com/toolsCode.php).
+0xxx EBCDIC codesets were taken from [longpelaexpertise.com](http://www.longpelaexpertise.com/toolsCode.php).
+1047 EBCDIC codeset was taken from [this source](https://zims-en.kiwix.campusafrica.gos.orange.com/wikipedia_en_all_nopic/A/EBCDIC_1047).
 
 ## Usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,8 @@
-import englishCodeset from "./tables/0037"
-import germanCodeset from "./tables/0273"
-import finsweCodeset from "./tables/0278"
+import { ConvTableName, convTables, IConvTableEntry } from "./tables"
 import iconv from "iconv-lite"
 
-interface IConvTableEntry {
-  hex: string
-  ebcdic: string
-  ascii: string
-}
 type ConvTable = IConvTableEntry[]
-type ConvTableName = "0273" | "0037" | "0278"
 type QuickLookupTable = { [name: string]: string }
-
-const convTables = {
-  "0273": germanCodeset,
-  "0037": englishCodeset,
-  "0278": finsweCodeset,
-}
 
 /**
  * Class for converting between EBCDIC and ASCII (ISO-8859-1)
@@ -35,9 +21,9 @@ export default class EbcdicAscii {
 
   setTable(tableName: ConvTableName) {
     const simpleTable: ConvTable = convTables[tableName]
-    
+
     simpleTable.forEach((tableItem) => {
-      const asciiCode: string = tableItem.hex; 
+      const asciiCode: string = tableItem.hex
       const ebcdicEntry = simpleTable.find((e) => e.ebcdic === tableItem?.ascii)
       const ebcdicCode: string = ebcdicEntry ? ebcdicEntry.hex : "00"
 
@@ -93,11 +79,11 @@ export default class EbcdicAscii {
    * @param ebcdic string - Hex code for a EBCDIC char
    */
   charToASCII(ebcdicCode: string) {
-    const asciiCode = this.ebcdicToAsciiTable[ebcdicCode];
+    const asciiCode = this.ebcdicToAsciiTable[ebcdicCode]
     if (asciiCode === undefined) {
       throw new Error(`Invalid char sequence ${ebcdicCode}`)
     }
-    return asciiCode; 
+    return asciiCode
   }
 
   /**
@@ -105,10 +91,10 @@ export default class EbcdicAscii {
    * @param ascii string - Hex code for an ASCII char
    */
   charToEBCDIC(asciiCode: string) {
-    const ebcdicCode = this.asciiToEbcdicTable[asciiCode];
+    const ebcdicCode = this.asciiToEbcdicTable[asciiCode]
     if (ebcdicCode === undefined) {
       throw new Error(`Invalid char sequence ${asciiCode}`)
     }
-    return ebcdicCode; 
+    return ebcdicCode
   }
 }

--- a/src/tables/0037.ts
+++ b/src/tables/0037.ts
@@ -194,7 +194,7 @@ export default [
   {
     hex: "26",
     ebcdic: "ETB",
-    ascii: "&amp;",
+    ascii: "&",
   },
   {
     hex: "27",
@@ -304,7 +304,7 @@ export default [
   {
     hex: "3C",
     ebcdic: "DC4",
-    ascii: "&lt;",
+    ascii: "<",
   },
   {
     hex: "3D",
@@ -314,7 +314,7 @@ export default [
   {
     hex: "3E",
     ebcdic: " ",
-    ascii: "&gt;",
+    ascii: ">",
   },
   {
     hex: "3F",
@@ -383,7 +383,7 @@ export default [
   },
   {
     hex: "4C",
-    ebcdic: "&lt;",
+    ebcdic: "<",
     ascii: "L",
   },
   {
@@ -403,7 +403,7 @@ export default [
   },
   {
     hex: "50",
-    ebcdic: "&amp;",
+    ebcdic: "&",
     ascii: "P",
   },
   {
@@ -553,7 +553,7 @@ export default [
   },
   {
     hex: "6E",
-    ebcdic: "&gt;",
+    ebcdic: ">",
     ascii: "n",
   },
   {
@@ -639,7 +639,7 @@ export default [
   {
     hex: "7F",
     ebcdic: '"',
-    ascii: "",
+    ascii: "",
   },
   {
     hex: "80",

--- a/src/tables/0273.ts
+++ b/src/tables/0273.ts
@@ -194,7 +194,7 @@ export default [
   {
     hex: "26",
     ebcdic: "ETB",
-    ascii: "&amp;",
+    ascii: "&",
   },
   {
     hex: "27",
@@ -304,7 +304,7 @@ export default [
   {
     hex: "3C",
     ebcdic: "DC4",
-    ascii: "&lt;",
+    ascii: "<",
   },
   {
     hex: "3D",
@@ -314,7 +314,7 @@ export default [
   {
     hex: "3E",
     ebcdic: " ",
-    ascii: "&gt;",
+    ascii: ">",
   },
   {
     hex: "3F",
@@ -383,7 +383,7 @@ export default [
   },
   {
     hex: "4C",
-    ebcdic: "&lt;",
+    ebcdic: "<",
     ascii: "L",
   },
   {
@@ -403,7 +403,7 @@ export default [
   },
   {
     hex: "50",
-    ebcdic: "&amp;",
+    ebcdic: "&",
     ascii: "P",
   },
   {
@@ -553,7 +553,7 @@ export default [
   },
   {
     hex: "6E",
-    ebcdic: "&gt;",
+    ebcdic: ">",
     ascii: "n",
   },
   {
@@ -639,7 +639,7 @@ export default [
   {
     hex: "7F",
     ebcdic: '"',
-    ascii: "",
+    ascii: "",
   },
   {
     hex: "80",

--- a/src/tables/0278.ts
+++ b/src/tables/0278.ts
@@ -154,7 +154,7 @@ export default [
   { hex: "96", ebcdic: "o", ascii: "SPA" },
   { hex: "97", ebcdic: "p", ascii: "EPA" },
   { hex: "98", ebcdic: "q", ascii: "SOS" },
-  { hex: "99", ebcdic: "r", ascii: "" },
+  { hex: "99", ebcdic: "r", ascii: " " },
   { hex: "9A", ebcdic: "ª", ascii: "SCI" },
   { hex: "9B", ebcdic: "º", ascii: "CSI" },
   { hex: "9C", ebcdic: "æ", ascii: "ST" },

--- a/src/tables/1047.ts
+++ b/src/tables/1047.ts
@@ -1,0 +1,1285 @@
+// EBCDIC 1047: Latin 1/Open Systems
+// Source: https://zims-en.kiwix.campusafrica.gos.orange.com/wikipedia_en_all_nopic/A/EBCDIC_1047
+
+export default [
+  {
+    hex: "00",
+    ascii: "Null",
+    ebcdic: "Null",
+  },
+  {
+    hex: "01",
+    ascii: "SOH",
+    ebcdic: "SOH",
+  },
+  {
+    hex: "02",
+    ascii: "STX",
+    ebcdic: "STX",
+  },
+  {
+    hex: "03",
+    ascii: "ETX",
+    ebcdic: "ETX",
+  },
+  {
+    hex: "04",
+    ascii: "EOT",
+    ebcdic: "",
+  },
+  {
+    hex: "05",
+    ascii: "ENQ",
+    ebcdic: "HT",
+  },
+  {
+    hex: "06",
+    ascii: "ACK",
+    ebcdic: "",
+  },
+  {
+    hex: "07",
+    ascii: "Bell",
+    ebcdic: "DEL",
+  },
+  {
+    hex: "08",
+    ascii: "Backspace",
+    ebcdic: "",
+  },
+  {
+    hex: "09",
+    ascii: "HT",
+    ebcdic: "",
+  },
+  {
+    hex: "0A",
+    ascii: "Line Feed",
+    ebcdic: "",
+  },
+  {
+    hex: "0B",
+    ascii: "VT",
+    ebcdic: "VT",
+  },
+  {
+    hex: "0C",
+    ascii: "Form Feed",
+    ebcdic: "FF",
+  },
+  {
+    hex: "0D",
+    ascii: "Carriage Return",
+    ebcdic: "CR",
+  },
+  {
+    hex: "0E",
+    ascii: "SO",
+    ebcdic: "SO",
+  },
+  {
+    hex: "0F",
+    ascii: "SI",
+    ebcdic: "SI",
+  },
+  {
+    hex: "10",
+    ascii: "DLE",
+    ebcdic: "DLE",
+  },
+  {
+    hex: "11",
+    ascii: "DC1",
+    ebcdic: "DC1",
+  },
+  {
+    hex: "12",
+    ascii: "DC2",
+    ebcdic: "DC2",
+  },
+  {
+    hex: "13",
+    ascii: "DC3",
+    ebcdic: "DC3",
+  },
+  {
+    hex: "14",
+    ascii: "DC4",
+    ebcdic: "",
+  },
+  {
+    hex: "15",
+    ascii: "NAK",
+    ebcdic: "NL",
+  },
+  {
+    hex: "16",
+    ascii: "SYN",
+    ebcdic: "BS",
+  },
+  {
+    hex: "17",
+    ascii: "ETB",
+    ebcdic: "",
+  },
+  {
+    hex: "18",
+    ascii: "CAN",
+    ebcdic: "CAN",
+  },
+  {
+    hex: "19",
+    ascii: "EM",
+    ebcdic: "EM",
+  },
+  {
+    hex: "1A",
+    ascii: "SUB",
+    ebcdic: "",
+  },
+  {
+    hex: "1B",
+    ascii: "ESC",
+    ebcdic: "",
+  },
+  {
+    hex: "1C",
+    ascii: "IFS",
+    ebcdic: "IFS",
+  },
+  {
+    hex: "1D",
+    ascii: "IGS",
+    ebcdic: "IGS",
+  },
+  {
+    hex: "1E",
+    ascii: "IRS",
+    ebcdic: "IRS",
+  },
+  {
+    hex: "1F",
+    ascii: "IUS",
+    ebcdic: "ius",
+  },
+  {
+    hex: "20",
+    ascii: "Space",
+    ebcdic: "",
+  },
+  {
+    hex: "21",
+    ascii: "!",
+    ebcdic: "",
+  },
+  {
+    hex: "22",
+    ascii: '"',
+    ebcdic: "",
+  },
+  {
+    hex: "23",
+    ascii: "#",
+    ebcdic: "",
+  },
+  {
+    hex: "24",
+    ascii: "$",
+    ebcdic: "",
+  },
+  {
+    hex: "25",
+    ascii: "%",
+    ebcdic: "LF",
+  },
+  {
+    hex: "26",
+    ascii: "&",
+    ebcdic: "ETB",
+  },
+  {
+    hex: "27",
+    ascii: "'",
+    ebcdic: "ESC",
+  },
+  {
+    hex: "28",
+    ascii: "(",
+    ebcdic: "",
+  },
+  {
+    hex: "29",
+    ascii: ")",
+    ebcdic: "",
+  },
+  {
+    hex: "2A",
+    ascii: "*",
+    ebcdic: "",
+  },
+  {
+    hex: "2B",
+    ascii: "+",
+    ebcdic: "",
+  },
+  {
+    hex: "2C",
+    ascii: ",",
+    ebcdic: "",
+  },
+  {
+    hex: "2D",
+    ascii: "-",
+    ebcdic: "ENQ",
+  },
+  {
+    hex: "2E",
+    ascii: ".",
+    ebcdic: "ACK",
+  },
+  {
+    hex: "2F",
+    ascii: "/",
+    ebcdic: "BEL",
+  },
+  {
+    hex: "30",
+    ascii: "0",
+    ebcdic: " ",
+  },
+  {
+    hex: "31",
+    ascii: "1",
+    ebcdic: " ",
+  },
+  {
+    hex: "32",
+    ascii: "2",
+    ebcdic: "SYN",
+  },
+  {
+    hex: "33",
+    ascii: "3",
+    ebcdic: "",
+  },
+  {
+    hex: "34",
+    ascii: "4",
+    ebcdic: "",
+  },
+  {
+    hex: "35",
+    ascii: "5",
+    ebcdic: "",
+  },
+  {
+    hex: "36",
+    ascii: "6",
+    ebcdic: "",
+  },
+  {
+    hex: "37",
+    ascii: "7",
+    ebcdic: "EOT",
+  },
+  {
+    hex: "38",
+    ascii: "8",
+    ebcdic: "",
+  },
+  {
+    hex: "39",
+    ascii: "9",
+    ebcdic: "",
+  },
+  {
+    hex: "3A",
+    ascii: ":",
+    ebcdic: "",
+  },
+  {
+    hex: "3B",
+    ascii: ";",
+    ebcdic: "",
+  },
+  {
+    hex: "3C",
+    ascii: "<",
+    ebcdic: "DC4",
+  },
+  {
+    hex: "3D",
+    ascii: "=",
+    ebcdic: "NAK",
+  },
+  {
+    hex: "3E",
+    ascii: ">",
+    ebcdic: " ",
+  },
+  {
+    hex: "3F",
+    ascii: "?",
+    ebcdic: "SUB",
+  },
+  {
+    hex: "40",
+    ascii: "@",
+    ebcdic: "Space",
+  },
+  {
+    hex: "41",
+    ascii: "A",
+    ebcdic: "RSP",
+  },
+  {
+    hex: "42",
+    ascii: "B",
+    ebcdic: "â",
+  },
+  {
+    hex: "43",
+    ascii: "C",
+    ebcdic: "ä",
+  },
+  {
+    hex: "44",
+    ascii: "D",
+    ebcdic: "à",
+  },
+  {
+    hex: "45",
+    ascii: "E",
+    ebcdic: "á",
+  },
+  {
+    hex: "46",
+    ascii: "F",
+    ebcdic: "ã",
+  },
+  {
+    hex: "47",
+    ascii: "G",
+    ebcdic: "å",
+  },
+  {
+    hex: "48",
+    ascii: "H",
+    ebcdic: "ç",
+  },
+  {
+    hex: "49",
+    ascii: "I",
+    ebcdic: "ñ",
+  },
+  {
+    hex: "4A",
+    ascii: "J",
+    ebcdic: "¢",
+  },
+  {
+    hex: "4B",
+    ascii: "K",
+    ebcdic: ".",
+  },
+  {
+    hex: "4C",
+    ascii: "L",
+    ebcdic: "<",
+  },
+  {
+    hex: "4D",
+    ascii: "M",
+    ebcdic: "(",
+  },
+  {
+    hex: "4E",
+    ascii: "N",
+    ebcdic: "+",
+  },
+  {
+    hex: "4F",
+    ascii: "O",
+    ebcdic: "|",
+  },
+  {
+    hex: "50",
+    ascii: "P",
+    ebcdic: "&",
+  },
+  {
+    hex: "51",
+    ascii: "Q",
+    ebcdic: "é",
+  },
+  {
+    hex: "52",
+    ascii: "R",
+    ebcdic: "ê",
+  },
+  {
+    hex: "53",
+    ascii: "S",
+    ebcdic: "ë",
+  },
+  {
+    hex: "54",
+    ascii: "T",
+    ebcdic: "è",
+  },
+  {
+    hex: "55",
+    ascii: "U",
+    ebcdic: "í",
+  },
+  {
+    hex: "56",
+    ascii: "V",
+    ebcdic: "î",
+  },
+  {
+    hex: "57",
+    ascii: "W",
+    ebcdic: "ï",
+  },
+  {
+    hex: "58",
+    ascii: "X",
+    ebcdic: "ì",
+  },
+  {
+    hex: "59",
+    ascii: "Y",
+    ebcdic: "ß",
+  },
+  {
+    hex: "5A",
+    ascii: "Z",
+    ebcdic: "!",
+  },
+  {
+    hex: "5B",
+    ascii: "[",
+    ebcdic: "$",
+  },
+  {
+    hex: "5C",
+    ascii: "\\",
+    ebcdic: "*",
+  },
+  {
+    hex: "5D",
+    ascii: "]",
+    ebcdic: ")",
+  },
+  {
+    hex: "5E",
+    ascii: "^",
+    ebcdic: ";",
+  },
+  {
+    hex: "5F",
+    ascii: "_",
+    ebcdic: "^",
+  },
+  {
+    hex: "60",
+    ascii: "`",
+    ebcdic: "-",
+  },
+  {
+    hex: "61",
+    ascii: "a",
+    ebcdic: "/",
+  },
+  {
+    hex: "62",
+    ascii: "b",
+    ebcdic: "Â",
+  },
+  {
+    hex: "63",
+    ascii: "c",
+    ebcdic: "Ä",
+  },
+  {
+    hex: "64",
+    ascii: "d",
+    ebcdic: "À",
+  },
+  {
+    hex: "65",
+    ascii: "e",
+    ebcdic: "Á",
+  },
+  {
+    hex: "66",
+    ascii: "f",
+    ebcdic: "Ã",
+  },
+  {
+    hex: "67",
+    ascii: "g",
+    ebcdic: "Å",
+  },
+  {
+    hex: "68",
+    ascii: "h",
+    ebcdic: "Ç",
+  },
+  {
+    hex: "69",
+    ascii: "i",
+    ebcdic: "Ñ",
+  },
+  {
+    hex: "6A",
+    ascii: "j",
+    ebcdic: "¦",
+  },
+  {
+    hex: "6B",
+    ascii: "k",
+    ebcdic: ",",
+  },
+  {
+    hex: "6C",
+    ascii: "l",
+    ebcdic: "%",
+  },
+  {
+    hex: "6D",
+    ascii: "m",
+    ebcdic: "_",
+  },
+  {
+    hex: "6E",
+    ascii: "n",
+    ebcdic: ">",
+  },
+  {
+    hex: "6F",
+    ascii: "o",
+    ebcdic: "?",
+  },
+  {
+    hex: "70",
+    ascii: "p",
+    ebcdic: "ø",
+  },
+  {
+    hex: "71",
+    ascii: "q",
+    ebcdic: "É",
+  },
+  {
+    hex: "72",
+    ascii: "r",
+    ebcdic: "Ê",
+  },
+  {
+    hex: "73",
+    ascii: "s",
+    ebcdic: "Ë",
+  },
+  {
+    hex: "74",
+    ascii: "t",
+    ebcdic: "È",
+  },
+  {
+    hex: "75",
+    ascii: "u",
+    ebcdic: "Í",
+  },
+  {
+    hex: "76",
+    ascii: "v",
+    ebcdic: "Î",
+  },
+  {
+    hex: "77",
+    ascii: "w",
+    ebcdic: "Ï",
+  },
+  {
+    hex: "78",
+    ascii: "x",
+    ebcdic: "Ì",
+  },
+  {
+    hex: "79",
+    ascii: "y",
+    ebcdic: "`",
+  },
+  {
+    hex: "7A",
+    ascii: "z",
+    ebcdic: ":",
+  },
+  {
+    hex: "7B",
+    ascii: "{",
+    ebcdic: "#",
+  },
+  {
+    hex: "7C",
+    ascii: "|",
+    ebcdic: "@",
+  },
+  {
+    hex: "7D",
+    ascii: "}",
+    ebcdic: "'",
+  },
+  {
+    hex: "7E",
+    ascii: "~",
+    ebcdic: "=",
+  },
+  {
+    hex: "7F",
+    ascii: "",
+    ebcdic: '"',
+  },
+  {
+    hex: "80",
+    ascii: "",
+    ebcdic: "Ø",
+  },
+  {
+    hex: "81",
+    ascii: "",
+    ebcdic: "a",
+  },
+  {
+    hex: "82",
+    ascii: "BPH",
+    ebcdic: "b",
+  },
+  {
+    hex: "83",
+    ascii: "NBH",
+    ebcdic: "c",
+  },
+  {
+    hex: "84",
+    ascii: "IND",
+    ebcdic: "d",
+  },
+  {
+    hex: "85",
+    ascii: "Next Line",
+    ebcdic: "e",
+  },
+  {
+    hex: "86",
+    ascii: "SSA",
+    ebcdic: "f",
+  },
+  {
+    hex: "87",
+    ascii: "ESA",
+    ebcdic: "g",
+  },
+  {
+    hex: "88",
+    ascii: "HTS",
+    ebcdic: "h",
+  },
+  {
+    hex: "89",
+    ascii: "HTJ",
+    ebcdic: "i",
+  },
+  {
+    hex: "8A",
+    ascii: "VTS",
+    ebcdic: "«",
+  },
+  {
+    hex: "8B",
+    ascii: "PLD",
+    ebcdic: "»",
+  },
+  {
+    hex: "8C",
+    ascii: "PLU",
+    ebcdic: "ð",
+  },
+  {
+    hex: "8D",
+    ascii: "RI",
+    ebcdic: "ý",
+  },
+  {
+    hex: "8E",
+    ascii: "SS2",
+    ebcdic: "þ",
+  },
+  {
+    hex: "8F",
+    ascii: "SS3",
+    ebcdic: "±",
+  },
+  {
+    hex: "90",
+    ascii: "DCS",
+    ebcdic: "°",
+  },
+  {
+    hex: "91",
+    ascii: "PU1",
+    ebcdic: "j",
+  },
+  {
+    hex: "92",
+    ascii: "PU2",
+    ebcdic: "k",
+  },
+  {
+    hex: "93",
+    ascii: "STS",
+    ebcdic: "l",
+  },
+  {
+    hex: "94",
+    ascii: "CCH",
+    ebcdic: "m",
+  },
+  {
+    hex: "95",
+    ascii: "MW",
+    ebcdic: "n",
+  },
+  {
+    hex: "96",
+    ascii: "SPA",
+    ebcdic: "o",
+  },
+  {
+    hex: "97",
+    ascii: "EPA",
+    ebcdic: "p",
+  },
+  {
+    hex: "98",
+    ascii: "SOS",
+    ebcdic: "q",
+  },
+  {
+    hex: "99",
+    ascii: " ",
+    ebcdic: "r",
+  },
+  {
+    hex: "9A",
+    ascii: "SCI",
+    ebcdic: "",
+  },
+  {
+    hex: "9B",
+    ascii: "CSI",
+    ebcdic: "",
+  },
+  {
+    hex: "9C",
+    ascii: "ST",
+    ebcdic: "æ",
+  },
+  {
+    hex: "9D",
+    ascii: "OSC",
+    ebcdic: "¸",
+  },
+  {
+    hex: "9E",
+    ascii: "PM",
+    ebcdic: "Æ",
+  },
+  {
+    hex: "9F",
+    ascii: "APC",
+    ebcdic: "¤",
+  },
+  {
+    hex: "A0",
+    ascii: "RSP",
+    ebcdic: "µ",
+  },
+  {
+    hex: "A1",
+    ascii: "¡",
+    ebcdic: "~",
+  },
+  {
+    hex: "A2",
+    ascii: "¢",
+    ebcdic: "s",
+  },
+  {
+    hex: "A3",
+    ascii: "£",
+    ebcdic: "t",
+  },
+  {
+    hex: "A4",
+    ascii: "¤",
+    ebcdic: "u",
+  },
+  {
+    hex: "A5",
+    ascii: "¥",
+    ebcdic: "v",
+  },
+  {
+    hex: "A6",
+    ascii: "¦",
+    ebcdic: "w",
+  },
+  {
+    hex: "A7",
+    ascii: "§",
+    ebcdic: "x",
+  },
+  {
+    hex: "A8",
+    ascii: "¨",
+    ebcdic: "y",
+  },
+  {
+    hex: "A9",
+    ascii: "©",
+    ebcdic: "z",
+  },
+  {
+    hex: "AA",
+    ascii: "ª",
+    ebcdic: "¡",
+  },
+  {
+    hex: "AB",
+    ascii: "«",
+    ebcdic: "¿",
+  },
+  {
+    hex: "AC",
+    ascii: "¬",
+    ebcdic: "Ð",
+  },
+  {
+    hex: "AD",
+    ascii: "Syllable Hyphen",
+    ebcdic: "[",
+  },
+  {
+    hex: "AE",
+    ascii: "®",
+    ebcdic: "Þ",
+  },
+  {
+    hex: "AF",
+    ascii: "¯",
+    ebcdic: "®",
+  },
+  {
+    hex: "B0",
+    ascii: "°",
+    ebcdic: "¬",
+  },
+  {
+    hex: "B1",
+    ascii: "±",
+    ebcdic: "£",
+  },
+  {
+    hex: "B2",
+    ascii: "²",
+    ebcdic: "¥",
+  },
+  {
+    hex: "B3",
+    ascii: "³",
+    ebcdic: "·",
+  },
+  {
+    hex: "B4",
+    ascii: "´",
+    ebcdic: "©",
+  },
+  {
+    hex: "B5",
+    ascii: "µ",
+    ebcdic: "§",
+  },
+  {
+    hex: "B6",
+    ascii: "¶",
+    ebcdic: "¶",
+  },
+  {
+    hex: "B7",
+    ascii: "·",
+    ebcdic: "¼",
+  },
+  {
+    hex: "B8",
+    ascii: "¸",
+    ebcdic: "½",
+  },
+  {
+    hex: "B9",
+    ascii: "¹",
+    ebcdic: "¾",
+  },
+  {
+    hex: "BA",
+    ascii: "º",
+    ebcdic: "Ý",
+  },
+  {
+    hex: "BB",
+    ascii: "»",
+    ebcdic: "¨",
+  },
+  {
+    hex: "BC",
+    ascii: "¼",
+    ebcdic: "¯",
+  },
+  {
+    hex: "BD",
+    ascii: "½",
+    ebcdic: "]",
+  },
+  {
+    hex: "BE",
+    ascii: "¾",
+    ebcdic: "´",
+  },
+  {
+    hex: "BF",
+    ascii: "¿",
+    ebcdic: "×",
+  },
+  {
+    hex: "C0",
+    ascii: "À",
+    ebcdic: "{",
+  },
+  {
+    hex: "C1",
+    ascii: "Á",
+    ebcdic: "A",
+  },
+  {
+    hex: "C2",
+    ascii: "Â",
+    ebcdic: "B",
+  },
+  {
+    hex: "C3",
+    ascii: "Ã",
+    ebcdic: "C",
+  },
+  {
+    hex: "C4",
+    ascii: "Ä",
+    ebcdic: "D",
+  },
+  {
+    hex: "C5",
+    ascii: "Å",
+    ebcdic: "E",
+  },
+  {
+    hex: "C6",
+    ascii: "Æ",
+    ebcdic: "F",
+  },
+  {
+    hex: "C7",
+    ascii: "Ç",
+    ebcdic: "G",
+  },
+  {
+    hex: "C8",
+    ascii: "È",
+    ebcdic: "H",
+  },
+  {
+    hex: "C9",
+    ascii: "É",
+    ebcdic: "I",
+  },
+  {
+    hex: "CA",
+    ascii: "Ê",
+    ebcdic: "SHY",
+  },
+  {
+    hex: "CB",
+    ascii: "Ë",
+    ebcdic: "ô",
+  },
+  {
+    hex: "CC",
+    ascii: "Ì",
+    ebcdic: "ö",
+  },
+  {
+    hex: "CD",
+    ascii: "Í",
+    ebcdic: "ò",
+  },
+  {
+    hex: "CE",
+    ascii: "Î",
+    ebcdic: "ó",
+  },
+  {
+    hex: "CF",
+    ascii: "Ï",
+    ebcdic: "õ",
+  },
+  {
+    hex: "D0",
+    ascii: "Ð",
+    ebcdic: "}",
+  },
+  {
+    hex: "D1",
+    ascii: "Ñ",
+    ebcdic: "J",
+  },
+  {
+    hex: "D2",
+    ascii: "Ò",
+    ebcdic: "K",
+  },
+  {
+    hex: "D3",
+    ascii: "Ó",
+    ebcdic: "L",
+  },
+  {
+    hex: "D4",
+    ascii: "Ô",
+    ebcdic: "M",
+  },
+  {
+    hex: "D5",
+    ascii: "Õ",
+    ebcdic: "N",
+  },
+  {
+    hex: "D6",
+    ascii: "Ö",
+    ebcdic: "O",
+  },
+  {
+    hex: "D7",
+    ascii: "×",
+    ebcdic: "P",
+  },
+  {
+    hex: "D8",
+    ascii: "Ø",
+    ebcdic: "Q",
+  },
+  {
+    hex: "D9",
+    ascii: "Ù",
+    ebcdic: "R",
+  },
+  {
+    hex: "DA",
+    ascii: "Ú",
+    ebcdic: "¹",
+  },
+  {
+    hex: "DB",
+    ascii: "Û",
+    ebcdic: "û",
+  },
+  {
+    hex: "DC",
+    ascii: "Ü",
+    ebcdic: "ü",
+  },
+  {
+    hex: "DD",
+    ascii: "Ý",
+    ebcdic: "ù",
+  },
+  {
+    hex: "DE",
+    ascii: "Þ",
+    ebcdic: "ú",
+  },
+  {
+    hex: "DF",
+    ascii: "ß",
+    ebcdic: "ÿ",
+  },
+  {
+    hex: "E0",
+    ascii: "à",
+    ebcdic: "\\",
+  },
+  {
+    hex: "E1",
+    ascii: "á",
+    ebcdic: "÷",
+  },
+  {
+    hex: "E2",
+    ascii: "â",
+    ebcdic: "S",
+  },
+  {
+    hex: "E3",
+    ascii: "ã",
+    ebcdic: "T",
+  },
+  {
+    hex: "E4",
+    ascii: "ä",
+    ebcdic: "U",
+  },
+  {
+    hex: "E5",
+    ascii: "å",
+    ebcdic: "V",
+  },
+  {
+    hex: "E6",
+    ascii: "æ",
+    ebcdic: "W",
+  },
+  {
+    hex: "E7",
+    ascii: "ç",
+    ebcdic: "X",
+  },
+  {
+    hex: "E8",
+    ascii: "è",
+    ebcdic: "Y",
+  },
+  {
+    hex: "E9",
+    ascii: "é",
+    ebcdic: "Z",
+  },
+  {
+    hex: "EA",
+    ascii: "ê",
+    ebcdic: "²",
+  },
+  {
+    hex: "EB",
+    ascii: "ë",
+    ebcdic: "Ô",
+  },
+  {
+    hex: "EC",
+    ascii: "ì",
+    ebcdic: "Ö",
+  },
+  {
+    hex: "ED",
+    ascii: "í",
+    ebcdic: "Ò",
+  },
+  {
+    hex: "EE",
+    ascii: "î",
+    ebcdic: "Ó",
+  },
+  {
+    hex: "EF",
+    ascii: "ï",
+    ebcdic: "Õ",
+  },
+  {
+    hex: "F0",
+    ascii: "ð",
+    ebcdic: "0",
+  },
+  {
+    hex: "F1",
+    ascii: "ñ",
+    ebcdic: "1",
+  },
+  {
+    hex: "F2",
+    ascii: "ò",
+    ebcdic: "2",
+  },
+  {
+    hex: "F3",
+    ascii: "ó",
+    ebcdic: "3",
+  },
+  {
+    hex: "F4",
+    ascii: "ô",
+    ebcdic: "4",
+  },
+  {
+    hex: "F5",
+    ascii: "õ",
+    ebcdic: "5",
+  },
+  {
+    hex: "F6",
+    ascii: "ö",
+    ebcdic: "6",
+  },
+  {
+    hex: "F7",
+    ascii: "÷",
+    ebcdic: "7",
+  },
+  {
+    hex: "F8",
+    ascii: "ø",
+    ebcdic: "8",
+  },
+  {
+    hex: "F9",
+    ascii: "ù",
+    ebcdic: "9",
+  },
+  {
+    hex: "FA",
+    ascii: "ú",
+    ebcdic: "³",
+  },
+  {
+    hex: "FB",
+    ascii: "û",
+    ebcdic: "Û",
+  },
+  {
+    hex: "FC",
+    ascii: "ü",
+    ebcdic: "Ü",
+  },
+  {
+    hex: "FD",
+    ascii: "ý",
+    ebcdic: "Ù",
+  },
+  {
+    hex: "FE",
+    ascii: "þ",
+    ebcdic: "Ú",
+  },
+  {
+    hex: "FF",
+    ascii: "ÿ",
+    ebcdic: "EO",
+  },
+]

--- a/src/tables/index.ts
+++ b/src/tables/index.ts
@@ -1,6 +1,7 @@
 import englishCodeset from "./0037"
 import germanCodeset from "./0273"
 import finsweCodeset from "./0278"
+import latinCodeset from "./1047"
 
 export interface IConvTableEntry {
   hex: string
@@ -8,10 +9,11 @@ export interface IConvTableEntry {
   ascii: string
 }
 
-export type ConvTableName = "0037" | "0273" | "0278"
+export type ConvTableName = "0037" | "0273" | "0278" | "1047"
 
 export const convTables: Record<ConvTableName, IConvTableEntry[]> = {
   "0037": englishCodeset,
   "0273": germanCodeset,
   "0278": finsweCodeset,
+  "1047": latinCodeset,
 }

--- a/src/tables/index.ts
+++ b/src/tables/index.ts
@@ -1,0 +1,17 @@
+import englishCodeset from "./0037"
+import germanCodeset from "./0273"
+import finsweCodeset from "./0278"
+
+export interface IConvTableEntry {
+  hex: string
+  ebcdic: string
+  ascii: string
+}
+
+export type ConvTableName = "0037" | "0273" | "0278"
+
+export const convTables: Record<ConvTableName, IConvTableEntry[]> = {
+  "0037": englishCodeset,
+  "0273": germanCodeset,
+  "0278": finsweCodeset,
+}

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -7,72 +7,103 @@ const ebcdicTestStringDE =
   "818283848586878889919293949596979899A2A3A4A5A6A7A8A9C1C2C3C4C5C6C7C8C9D1D2D3D4D5D6D7D8D9E2E3E4E5E6E7E8E9F0F1F2F3F4F5F6F7F8F96AD0C0E04A5AA1"
 const ebcdicTestStringFI_SE =
   "818283848586878889919293949596979899A2A3A4A5A6A7A8A9C1C2C3C4C5C6C7C8C9D1D2D3D4D5D6D7D8D9E2E3E4E5E6E7E8E9F0F1F2F3F4F5F6F7F8F9D0C06A5B7B7C"
+const ebcdicTestStringLatin =
+  "42434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFE40"
 
 describe("ebcdic-ascii", () => {
-  it("should resolve an english ebcdic string", () => {
-    const converter = new EBCDIC("0037")
+  describe("toASCII", () => {
+    it("should resolve an english ebcdic string", () => {
+      const converter = new EBCDIC("0037")
 
-    const ascii = converter.toASCII(ebcdicTestStringEN)
-    expect(ascii).toEqual("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+      const ascii = converter.toASCII(ebcdicTestStringEN)
+      expect(ascii).toEqual("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+    })
+
+    it("should resolve a german ebcdic string", () => {
+      const converter = new EBCDIC("0273")
+
+      const ascii = converter.toASCII(ebcdicTestStringDE)
+      expect(ascii).toEqual("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789öüäÖÄÜß")
+    })
+
+    it("should resolve a finnish/swedish ebcdic string", () => {
+      const converter = new EBCDIC("0278")
+
+      const ascii = converter.toASCII(ebcdicTestStringFI_SE)
+      expect(ascii).toEqual("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789åäöÅÄÖ")
+    })
+
+    it("should resolve a latin ebcdic string", () => {
+      const converter = new EBCDIC("1047")
+
+      const ascii = converter.toASCII(ebcdicTestStringLatin)
+      expect(ascii).toEqual(
+        "âäàáãåçñ¢.<(+|&éêëèíîïìß!$*);^-/ÂÄÀÁÃÅÇÑ¦,%_>?øÉÊËÈÍÎÏÌ`:#@'=\"Øabcdefghi«»ðýþ±°jklmnopqræ¸Æ¤µ~stuvwxyz¡¿Ð[Þ®¬£¥·©§¶¼½¾Ý¨¯]´×{ABCDEFGHIôöòóõ}JKLMNOPQR¹ûüùúÿ\\÷STUVWXYZ²ÔÖÒÓÕ0123456789³ÛÜÙÚ ",
+      )
+    })
   })
 
-  it("should resolve a german ebcdic string", () => {
-    const converter = new EBCDIC("0273")
+  describe("toEBCDIC", () => {
+    it("should convert english ASCII to EBCDIC and back", () => {
+      const converter = new EBCDIC("0037")
+      const expectedString = "English Test String!§$&/()=?"
+      const ebcdic = converter.toEBCDIC(Buffer.from(expectedString, "ascii").toString("hex"))
+      const ascii = converter.toASCII(ebcdic)
+      expect(ascii).toEqual(expectedString)
+    })
 
-    const ascii = converter.toASCII(ebcdicTestStringDE)
-    expect(ascii).toEqual("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789öüäÖÄÜß")
+    it("should convert german ASCII to EBCDIC and back", () => {
+      const converter = new EBCDIC("0273")
+      const expectedString = "ÖÄÜ öäü Test ßtring"
+      const ebcdic = converter.toEBCDIC(Buffer.from(expectedString, "ascii").toString("hex"))
+      const ascii = converter.toASCII(ebcdic)
+      expect(ascii).toEqual(expectedString)
+    })
+
+    it("should convert finnish/swedish ASCII to EBCDIC and back", () => {
+      const converter = new EBCDIC("0278")
+      const expectedString = "ÖÄÅ öäå Test String !@#¤%&/()[]{}^'*_-:.;,"
+      const ebcdic = converter.toEBCDIC(Buffer.from(expectedString, "ascii").toString("hex"))
+      const ascii = converter.toASCII(ebcdic)
+      expect(ascii).toEqual(expectedString)
+    })
+
+    it("should convert latin to EBCDIC and back", () => {
+      const converter = new EBCDIC("1047")
+      const expectedString = "âãáàêéèîíìôõóòúùü ç Test String !@#¤%&/()[]{}^'*_-:.;,"
+      const ebcdic = converter.toEBCDIC(Buffer.from(expectedString, "ascii").toString("hex"))
+      const ascii = converter.toASCII(ebcdic)
+      expect(ascii).toEqual(expectedString)
+    })
   })
 
-  it("should resolve a finnish/swedish ebcdic string", () => {
-    const converter = new EBCDIC("0278")
+  describe("toISO", () => {
+    it("should convert english EBCDIC to ISO and back", () => {
+      const converter = new EBCDIC("0037")
+      const isoHex = converter.toISO(ebcdicTestStringEN)
+      const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
+      expect(ebcdic).toEqual(ebcdicTestStringEN)
+    })
 
-    const ascii = converter.toASCII(ebcdicTestStringFI_SE)
-    expect(ascii).toEqual("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789åäöÅÄÖ")
-  })
+    it("should convert german EBCDIC to ISO and back", () => {
+      const converter = new EBCDIC("0273")
+      const isoHex = converter.toISO(ebcdicTestStringDE)
+      const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
+      expect(ebcdic).toEqual(ebcdicTestStringDE)
+    })
 
-  it("should convert english ASCII to EBCDIC and back", () => {
-    const converter = new EBCDIC("0273")
-    const ebcdic = converter.toEBCDIC(
-      Buffer.from("English Test String!§$&/()=?", "ascii").toString("hex"),
-    )
-    const ascii = converter.toASCII(ebcdic)
-    expect(ascii).toEqual("English Test String!§$&/()=?")
-  })
+    it("should convert finnish/swedish EBCDIC to ISO and back", () => {
+      const converter = new EBCDIC("0278")
+      const isoHex = converter.toISO(ebcdicTestStringFI_SE)
+      const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
+      expect(ebcdic).toEqual(ebcdicTestStringFI_SE)
+    })
 
-  it("should convert german ASCII to EBCDIC and back", () => {
-    const converter = new EBCDIC("0273")
-    const ebcdic = converter.toEBCDIC(Buffer.from("ÖÄÜ öäü Test ßtring", "ascii").toString("hex"))
-    const ascii = converter.toASCII(ebcdic)
-    expect(ascii).toEqual("ÖÄÜ öäü Test ßtring")
-  })
-
-  it("should convert finnish/swedish ASCII to EBCDIC and back", () => {
-    const converter = new EBCDIC("0278")
-    const ebcdic = converter.toEBCDIC(
-      Buffer.from("ÖÄÅ öäå Test String !@#¤%&/()[]{}^'*_-:.;,", "ascii").toString("hex"),
-    )
-    const ascii = converter.toASCII(ebcdic)
-    expect(ascii).toEqual("ÖÄÅ öäå Test String !@#¤%&/()[]{}^'*_-:.;,")
-  })
-
-  it("should convert german EBCDIC to ISO and back", () => {
-    const converter = new EBCDIC("0273")
-    const isoHex = converter.toISO(ebcdicTestStringDE)
-    const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
-    expect(ebcdic).toEqual(ebcdicTestStringDE)
-  })
-
-  it("should convert english EBCDIC to ISO and back", () => {
-    const converter = new EBCDIC("0037")
-    const isoHex = converter.toISO(ebcdicTestStringEN)
-    const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
-    expect(ebcdic).toEqual(ebcdicTestStringEN)
-  })
-
-  it("should convert finnish/swedish EBCDIC to ISO and back", () => {
-    const converter = new EBCDIC("0278")
-    const isoHex = converter.toISO(ebcdicTestStringFI_SE)
-    const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
-    expect(ebcdic).toEqual(ebcdicTestStringFI_SE)
+    it("should convert latin EBCDIC to ISO and back", () => {
+      const converter = new EBCDIC("1047")
+      const isoHex = converter.toISO(ebcdicTestStringLatin)
+      const ebcdic = converter.toEBCDIC(isoHex.toString("hex"))
+      expect(ebcdic).toEqual(ebcdicTestStringLatin)
+    })
   })
 })

--- a/src/test/tables.test.ts
+++ b/src/test/tables.test.ts
@@ -1,0 +1,29 @@
+import { convTables } from "../tables"
+
+function combine<T>(array: T[]) {
+  return array.flatMap((v, i) => array.slice(i + 1).map((w) => [v, w])) as [T, T][]
+}
+
+function combineWithName<T>(map: Record<string, T>) {
+  const array = Object.entries(map).map(([k, v]) => ({ k, v }))
+  return combine(array).map(([a, b]) => [a.k, b.k, a.v, b.v]) as [string, string, T, T][]
+}
+
+describe("tables", () => {
+  const combination = combineWithName(convTables)
+
+  test.each(combination)("%s codeset should have the same length as %s codeset", (_, __, a, b) => {
+    const aLength = a.length
+    const bLength = b.length
+    expect(aLength).toBe(bLength)
+  })
+
+  test.each(combination)(
+    "%s codeset should have the same ascii characters as %s codeset",
+    (_, __, a, b) => {
+      const aChars = a.map((c) => c.ascii)
+      const bChars = b.map((c) => c.ascii)
+      expect(aChars).toStrictEqual(bChars)
+    },
+  )
+})


### PR DESCRIPTION
Added support for 1047 Latin 1/Open Systems codeset.
Used https://zims-en.kiwix.campusafrica.gos.orange.com/wikipedia_en_all_nopic/A/EBCDIC_1047 for conversion table.
